### PR TITLE
Fixes issue #16

### DIFF
--- a/JeffFerguson.Gepsio.Test/IssueTests/SingleMethodIssueTests.cs
+++ b/JeffFerguson.Gepsio.Test/IssueTests/SingleMethodIssueTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Globalization;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JeffFerguson.Gepsio.Test.IssueTests
 {
@@ -85,6 +87,25 @@ namespace JeffFerguson.Gepsio.Test.IssueTests
                 }
             }
         }
+
+		/// <summary>
+		/// Ensure that decimal number parsing is culture independant.
+		/// For example french uses , (comma) as decimal separator.
+		/// </summary>
+		[TestMethod]
+		public void VerifyFixForIssue16()
+		{
+			try 
+			{
+				CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo( "fr" );
+				var xbrlDoc = new XbrlDocument( );
+				xbrlDoc.Load( "https://www.sec.gov/Archives/edgar/data/1688568/000168856818000036/csc-20170331.xml" );
+			} 
+			catch( System.FormatException ex ) 
+			{
+				Assert.Fail( "Decimal number format should be culture independant." );
+			}
+		}
 
         /// <summary>
         /// Ensure that the taxonomy at http://xbrl.fasb.org/us-gaap/2018/elts/us-gaap-2018-01-31.xsd

--- a/JeffFerguson.Gepsio/CalculationArc.cs
+++ b/JeffFerguson.Gepsio/CalculationArc.cs
@@ -2,6 +2,7 @@
 using JeffFerguson.Gepsio.Xml.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace JeffFerguson.Gepsio
 {
@@ -116,10 +117,10 @@ namespace JeffFerguson.Gepsio
             this.ToId = CalculationArcNode.GetAttributeValue(XlinkNode.xlinkNamespace, "to");
             string OrderString = CalculationArcNode.GetAttributeValue("order");
             if(string.IsNullOrEmpty(OrderString) == false)
-                this.Order = Convert.ToDecimal(OrderString);
+                this.Order = Convert.ToDecimal(OrderString, CultureInfo.InvariantCulture);
             string WeightString = CalculationArcNode.GetAttributeValue("weight");
             if (string.IsNullOrEmpty(WeightString) == false)
-                this.Weight = Convert.ToDecimal(WeightString);
+                this.Weight = Convert.ToDecimal(WeightString, CultureInfo.InvariantCulture);
             else
                 this.Weight = (decimal)(1.0);
             var useString = CalculationArcNode.GetAttributeValue("use");

--- a/JeffFerguson.Gepsio/Item.cs
+++ b/JeffFerguson.Gepsio/Item.cs
@@ -1,6 +1,7 @@
 ﻿using JeffFerguson.Gepsio.Xml.Interfaces;
 using JeffFerguson.Gepsio.Xsd;
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace JeffFerguson.Gepsio
@@ -552,7 +553,7 @@ namespace JeffFerguson.Gepsio
 
         private double GetRoundedValue()
         {
-            double RoundedValue = Convert.ToDouble(this.Value);
+            double RoundedValue = Convert.ToDouble(this.Value, CultureInfo.InvariantCulture);
             return Round(RoundedValue);
         }
 

--- a/JeffFerguson.Gepsio/Xsd/AnySimpleType.cs
+++ b/JeffFerguson.Gepsio/Xsd/AnySimpleType.cs
@@ -1,6 +1,7 @@
 ﻿using JeffFerguson.Gepsio.Xml.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Reflection; // needed for GetTypeInfo() in NETFX_CORE
 
@@ -82,7 +83,7 @@ namespace JeffFerguson.Gepsio.Xsd
         {
             if (this.NumericType == false)
                 throw new NotSupportedException();
-            decimal ValueAsDecimal = Convert.ToDecimal(this.ValueAsString);
+            decimal ValueAsDecimal = Convert.ToDecimal(this.ValueAsString, CultureInfo.InvariantCulture);
             if (PrecisionValue > 0)
             {
                 string WholePart;
@@ -102,7 +103,7 @@ namespace JeffFerguson.Gepsio.Xsd
                         TruncationBuilder.Append('0');
                     TruncationAsString = TruncationBuilder.ToString();
                 }
-                ValueAsDecimal = Convert.ToDecimal(TruncationAsString);
+                ValueAsDecimal = Convert.ToDecimal(TruncationAsString, CultureInfo.InvariantCulture);
             }
             return ValueAsDecimal;
         }
@@ -113,7 +114,7 @@ namespace JeffFerguson.Gepsio.Xsd
         {
             if (this.NumericType == false)
                 throw new NotSupportedException();
-            decimal ValueAsDecimal = Convert.ToDecimal(this.ValueAsString);
+            decimal ValueAsDecimal = Convert.ToDecimal(this.ValueAsString, CultureInfo.InvariantCulture);
             if (DecimalsValue > 0)
                 ValueAsDecimal = Math.Round(ValueAsDecimal, DecimalsValue);
             return ValueAsDecimal;


### PR DESCRIPTION
Added CultureInfo.InvariantCulture in decimal number string parsing.
Added test case.

The issue #16 occurs when the OS default culture's decimal separator is not a dot.