### PR TITLE
Multiple linkbases - Fixes #48

### DIFF
--- a/Examples/CSharp/FactWeights/Program.cs
+++ b/Examples/CSharp/FactWeights/Program.cs
@@ -1,5 +1,6 @@
 ﻿using JeffFerguson.Gepsio;
 using System;
+using System.Linq;
 
 /// <summary>
 /// This sample, written by request from a Gepsio user, illustrates the correct way to
@@ -61,7 +62,7 @@ namespace FactWeights
                 {
                     if(currentSchema.CalculationLinkbase != null)
                     {
-                        return currentSchema.CalculationLinkbase;
+                        return currentSchema.CalculationLinkbase.FirstOrDefault();
                     }
                 }
             }

--- a/Examples/CSharp/FactWeights/Program.cs
+++ b/Examples/CSharp/FactWeights/Program.cs
@@ -60,9 +60,9 @@ namespace FactWeights
             {
                 foreach(var currentSchema in currentFragment.Schemas)
                 {
-                    if(currentSchema.CalculationLinkbase != null)
+                    if(currentSchema.CalculationLinkbases != null)
                     {
-                        return currentSchema.CalculationLinkbase.FirstOrDefault();
+                        return currentSchema.CalculationLinkbases.FirstOrDefault();
                     }
                 }
             }

--- a/JeffFerguson.Gepsio/Item.cs
+++ b/JeffFerguson.Gepsio/Item.cs
@@ -576,7 +576,7 @@ namespace JeffFerguson.Gepsio
 
             double RoundedValue = OriginalValue;
 
-            string OriginalValueAsString = OriginalValue.ToString();
+            string OriginalValueAsString = OriginalValue.ToString(CultureInfo.InvariantCulture);
             string[] ComponentParts = ParseValueIntoComponentParts(OriginalValueAsString);
             var leftOfDecimal = ComponentParts[0].TrimStart(new char[] { '0' });
             var leftOfDecimalLength = leftOfDecimal.Length;

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -91,7 +91,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's reference linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public ReferenceLinkbaseDocument ReferenceLinkbase
+        public IEnumerable< ReferenceLinkbaseDocument > ReferenceLinkbase
         {
             get
             {
@@ -100,10 +100,9 @@ namespace JeffFerguson.Gepsio
                     foreach (var currentLinkbaseDocument in thisLinkbaseDocuments)
                     {
                         if (currentLinkbaseDocument is ReferenceLinkbaseDocument)
-                            return currentLinkbaseDocument as ReferenceLinkbaseDocument;
+                            yield return currentLinkbaseDocument as ReferenceLinkbaseDocument;
                     }
                 }
-                return null;
             }
         }
 

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -76,7 +76,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's presentation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public PresentationLinkbaseDocument PresentationLinkbase
+        public IEnumerable<PresentationLinkbaseDocument> PresentationLinkbase
         {
             get
             {
@@ -85,11 +85,10 @@ namespace JeffFerguson.Gepsio
                     foreach (var currentLinkbaseDocument in thisLinkbaseDocuments)
                     {
                         if (currentLinkbaseDocument is PresentationLinkbaseDocument)
-                            return currentLinkbaseDocument as PresentationLinkbaseDocument;
+                            yield return currentLinkbaseDocument as PresentationLinkbaseDocument;
                     }
                 }
-                return null;
-            }
+			}
         }
 
         /// <summary>

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -38,7 +38,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's definition linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public DefinitionLinkbaseDocument DefinitionLinkbase
+        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbase
         {
             get
             {
@@ -47,10 +47,9 @@ namespace JeffFerguson.Gepsio
                     foreach (var currentLinkbaseDocument in thisLinkbaseDocuments)
                     {
                         if (currentLinkbaseDocument is DefinitionLinkbaseDocument)
-                            return currentLinkbaseDocument as DefinitionLinkbaseDocument;
+                            yield return currentLinkbaseDocument as DefinitionLinkbaseDocument;
                     }
                 }
-                return null;
             }
         }
 

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -19,7 +19,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's calculation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public CalculationLinkbaseDocument CalculationLinkbase
+        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbase
         {
             get
             {
@@ -28,10 +28,9 @@ namespace JeffFerguson.Gepsio
                     foreach (var currentLinkbaseDocument in thisLinkbaseDocuments)
                     {
                         if (currentLinkbaseDocument is CalculationLinkbaseDocument)
-                            return currentLinkbaseDocument as CalculationLinkbaseDocument;
+                            yield return currentLinkbaseDocument as CalculationLinkbaseDocument;
                     }
                 }
-                return null;
             }
         }
 

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -19,7 +19,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's calculation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbase
+        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbases
         {
             get
             {
@@ -37,7 +37,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's definition linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbase
+        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbases
         {
             get
             {
@@ -55,7 +55,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's label linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-		public IEnumerable< LabelLinkbaseDocument > LabelLinkbase
+		public IEnumerable< LabelLinkbaseDocument > LabelLinkbases
         {
             get
             {
@@ -73,7 +73,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's presentation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable<PresentationLinkbaseDocument> PresentationLinkbase
+        public IEnumerable<PresentationLinkbaseDocument> PresentationLinkbases
         {
             get
             {
@@ -91,7 +91,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's reference linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< ReferenceLinkbaseDocument > ReferenceLinkbase
+        public IEnumerable< ReferenceLinkbaseDocument > ReferenceLinkbases
         {
             get
             {

--- a/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
+++ b/JeffFerguson.Gepsio/LinkbaseDocumentCollection.cs
@@ -57,7 +57,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's label linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public LabelLinkbaseDocument LabelLinkbase
+		public IEnumerable< LabelLinkbaseDocument > LabelLinkbase
         {
             get
             {
@@ -66,10 +66,9 @@ namespace JeffFerguson.Gepsio
                     foreach (var currentLinkbaseDocument in thisLinkbaseDocuments)
                     {
                         if (currentLinkbaseDocument is LabelLinkbaseDocument)
-                            return currentLinkbaseDocument as LabelLinkbaseDocument;
+                            yield return currentLinkbaseDocument as LabelLinkbaseDocument;
                     }
                 }
-                return null;
             }
         }
 

--- a/JeffFerguson.Gepsio/PresentableFactTree.cs
+++ b/JeffFerguson.Gepsio/PresentableFactTree.cs
@@ -95,7 +95,7 @@ namespace JeffFerguson.Gepsio
             var labelLinkbase = schema.LabelLinkbase;
             if (labelLinkbase == null)
                 return string.Empty;
-            foreach(var labelLink in labelLinkbase.LabelLinks)
+            foreach(var labelLink in labelLinkbase.SelectMany(x => x.LabelLinks))
             {
                 var foundLabel = GetLabel(schema, labelLocator, labelLink);
                 if (string.IsNullOrEmpty(foundLabel) == false)

--- a/JeffFerguson.Gepsio/PresentableFactTree.cs
+++ b/JeffFerguson.Gepsio/PresentableFactTree.cs
@@ -28,7 +28,7 @@ namespace JeffFerguson.Gepsio
         internal PresentableFactTree(XbrlSchema schema, FactCollection facts)
         {
             TopLevelNodes = new List<PresentableFactTreeNode>();
-            var presentationLinkbase = schema.PresentationLinkbase;
+            var presentationLinkbase = schema.PresentationLinkbases;
 			foreach( var presentationLink in presentationLinkbase.SelectMany( x => x.PresentationLinks ) )
             {
                 var unorderedPresentationArcs = presentationLink.PresentationArcs;
@@ -92,7 +92,7 @@ namespace JeffFerguson.Gepsio
         /// </returns>
         private string GetLabel(XbrlSchema schema, Locator labelLocator)
         {
-            var labelLinkbase = schema.LabelLinkbase;
+            var labelLinkbase = schema.LabelLinkbases;
             if (labelLinkbase == null)
                 return string.Empty;
             foreach(var labelLink in labelLinkbase.SelectMany(x => x.LabelLinks))
@@ -122,7 +122,7 @@ namespace JeffFerguson.Gepsio
         /// </returns>
         private string GetLabel(XbrlSchema schema, Locator labelLocator, LabelLink labelLink)
         {
-            var labelLinkbase = schema.LabelLinkbase;
+            var labelLinkbase = schema.LabelLinkbases;
             if (labelLinkbase == null)
                 return string.Empty;
 

--- a/JeffFerguson.Gepsio/PresentableFactTree.cs
+++ b/JeffFerguson.Gepsio/PresentableFactTree.cs
@@ -29,7 +29,7 @@ namespace JeffFerguson.Gepsio
         {
             TopLevelNodes = new List<PresentableFactTreeNode>();
             var presentationLinkbase = schema.PresentationLinkbase;
-            foreach (var presentationLink in presentationLinkbase.PresentationLinks)
+			foreach( var presentationLink in presentationLinkbase.SelectMany( x => x.PresentationLinks ) )
             {
                 var unorderedPresentationArcs = presentationLink.PresentationArcs;
                 var orderedPresentationArcs = unorderedPresentationArcs.OrderBy(o => o.Order).ToList();

--- a/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/SummationConceptValidator.cs
+++ b/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/SummationConceptValidator.cs
@@ -37,7 +37,7 @@ namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
         /// </param>
         private void Validate(XbrlSchema CurrentSchema)
         {
-            var calculationLinkbase = CurrentSchema.CalculationLinkbase;
+            var calculationLinkbase = CurrentSchema.CalculationLinkbases;
             if (calculationLinkbase == null)
                 return;
             foreach (CalculationLink CurrentCalculationLink in calculationLinkbase.SelectMany(x=>x.CalculationLinks))

--- a/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/SummationConceptValidator.cs
+++ b/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/SummationConceptValidator.cs
@@ -1,5 +1,6 @@
 ﻿using JeffFerguson.Gepsio.Xsd;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
@@ -39,7 +40,7 @@ namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
             var calculationLinkbase = CurrentSchema.CalculationLinkbase;
             if (calculationLinkbase == null)
                 return;
-            foreach (CalculationLink CurrentCalculationLink in calculationLinkbase.CalculationLinks)
+            foreach (CalculationLink CurrentCalculationLink in calculationLinkbase.SelectMany(x=>x.CalculationLinks))
                 Validate(CurrentCalculationLink);
         }
 

--- a/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/Xbrl2Dot1Validator.cs
+++ b/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/Xbrl2Dot1Validator.cs
@@ -398,7 +398,7 @@ namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
         {
             foreach (var currentSchema in validatingFragment.Schemas.SchemaList)
             {
-                var currentDefinitionLinkbaseDocument = currentSchema.DefinitionLinkbase;
+                var currentDefinitionLinkbaseDocument = currentSchema.DefinitionLinkbases;
                 if (currentDefinitionLinkbaseDocument != null)
                 {
 					foreach( DefinitionLink CurrentDefinitionLink in currentDefinitionLinkbaseDocument.SelectMany( x => x.DefinitionLinks ) )

--- a/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/Xbrl2Dot1Validator.cs
+++ b/JeffFerguson.Gepsio/Validators/Xbrl2Dot1/Xbrl2Dot1Validator.cs
@@ -1,6 +1,7 @@
 ﻿using JeffFerguson.Gepsio.Xsd;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
@@ -400,7 +401,7 @@ namespace JeffFerguson.Gepsio.Validators.Xbrl2Dot1
                 var currentDefinitionLinkbaseDocument = currentSchema.DefinitionLinkbase;
                 if (currentDefinitionLinkbaseDocument != null)
                 {
-                    foreach (DefinitionLink CurrentDefinitionLink in currentDefinitionLinkbaseDocument.DefinitionLinks)
+					foreach( DefinitionLink CurrentDefinitionLink in currentDefinitionLinkbaseDocument.SelectMany( x => x.DefinitionLinks ) )
                         ValidateFactsReferencedInDefinitionArcRoles(CurrentDefinitionLink);
                 }
             }

--- a/JeffFerguson.Gepsio/XbrlFragment.cs
+++ b/JeffFerguson.Gepsio/XbrlFragment.cs
@@ -555,8 +555,7 @@ namespace JeffFerguson.Gepsio
         internal CalculationArc GetCalculationArc(Locator toLocator)
         {
             var matchingArcs = new List<CalculationArc>();
-            var docReferencedCalculationLinkbase = thisLinkbaseDocuments.CalculationLinkbase;
-            if (docReferencedCalculationLinkbase != null)
+            foreach(var docReferencedCalculationLinkbase in thisLinkbaseDocuments.CalculationLinkbase)
             {
                 var matchingArc = docReferencedCalculationLinkbase.GetCalculationArc(toLocator);
                 if (matchingArc != null)
@@ -566,8 +565,7 @@ namespace JeffFerguson.Gepsio
             }
             foreach (var currentSchema in this.Schemas)
             {
-                var schemaCalcLinkbase = currentSchema.CalculationLinkbase;
-                if (schemaCalcLinkbase != null)
+                foreach(var schemaCalcLinkbase in currentSchema.CalculationLinkbase)
                 {
                     var matchingArc = schemaCalcLinkbase.GetCalculationArc(toLocator);
                     if (matchingArc != null)

--- a/JeffFerguson.Gepsio/XbrlFragment.cs
+++ b/JeffFerguson.Gepsio/XbrlFragment.cs
@@ -329,7 +329,7 @@ namespace JeffFerguson.Gepsio
         {
             foreach (var currentSchema in Schemas.SchemaList)
             {
-                if (currentSchema.PresentationLinkbase != null)
+                if (currentSchema.PresentationLinkbases != null)
                     return new PresentableFactTree(currentSchema, this.Facts);
             }
             return null;
@@ -555,7 +555,7 @@ namespace JeffFerguson.Gepsio
         internal CalculationArc GetCalculationArc(Locator toLocator)
         {
             var matchingArcs = new List<CalculationArc>();
-            foreach(var docReferencedCalculationLinkbase in thisLinkbaseDocuments.CalculationLinkbase)
+            foreach(var docReferencedCalculationLinkbase in thisLinkbaseDocuments.CalculationLinkbases)
             {
                 var matchingArc = docReferencedCalculationLinkbase.GetCalculationArc(toLocator);
                 if (matchingArc != null)
@@ -565,7 +565,7 @@ namespace JeffFerguson.Gepsio
             }
             foreach (var currentSchema in this.Schemas)
             {
-                foreach(var schemaCalcLinkbase in currentSchema.CalculationLinkbase)
+                foreach(var schemaCalcLinkbase in currentSchema.CalculationLinkbases)
                 {
                     var matchingArc = schemaCalcLinkbase.GetCalculationArc(toLocator);
                     if (matchingArc != null)

--- a/JeffFerguson.Gepsio/XbrlSchema.cs
+++ b/JeffFerguson.Gepsio/XbrlSchema.cs
@@ -94,7 +94,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's definition linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public DefinitionLinkbaseDocument DefinitionLinkbase => thisLinkbaseDocuments.DefinitionLinkbase;
+        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbase => thisLinkbaseDocuments.DefinitionLinkbase;
 
         /// <summary>
         /// A reference to the schema's label linkbase. Null is returned if no such linkbase is available.

--- a/JeffFerguson.Gepsio/XbrlSchema.cs
+++ b/JeffFerguson.Gepsio/XbrlSchema.cs
@@ -89,7 +89,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's calculation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public CalculationLinkbaseDocument CalculationLinkbase => thisLinkbaseDocuments.CalculationLinkbase;
+        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbase => thisLinkbaseDocuments.CalculationLinkbase;
 
         /// <summary>
         /// A reference to the schema's definition linkbase. Null is returned if no such linkbase is available.
@@ -291,10 +291,14 @@ namespace JeffFerguson.Gepsio
         {
             if (this.CalculationLinkbase == null)
                 return null;
-            var calculationLinkCandidate = CalculationLinkbase.GetCalculationLink(CalculationLinkRole);
-            if (calculationLinkCandidate != null)
-                return calculationLinkCandidate;
-            return null;
+
+			foreach( var linkbase in this.CalculationLinkbase ) 
+			{
+				var calculationLinkCandidate = linkbase.GetCalculationLink( CalculationLinkRole );
+				if( calculationLinkCandidate != null )
+					return calculationLinkCandidate;
+			}            
+			return null;
         }
 
         //-------------------------------------------------------------------------------

--- a/JeffFerguson.Gepsio/XbrlSchema.cs
+++ b/JeffFerguson.Gepsio/XbrlSchema.cs
@@ -89,22 +89,22 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's calculation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbase => thisLinkbaseDocuments.CalculationLinkbase;
+        public IEnumerable< CalculationLinkbaseDocument > CalculationLinkbases => thisLinkbaseDocuments.CalculationLinkbases;
 
         /// <summary>
         /// A reference to the schema's definition linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbase => thisLinkbaseDocuments.DefinitionLinkbase;
+        public IEnumerable< DefinitionLinkbaseDocument > DefinitionLinkbases => thisLinkbaseDocuments.DefinitionLinkbases;
 
         /// <summary>
         /// A reference to the schema's label linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< LabelLinkbaseDocument > LabelLinkbase => thisLinkbaseDocuments.LabelLinkbase;
+        public IEnumerable< LabelLinkbaseDocument > LabelLinkbases => thisLinkbaseDocuments.LabelLinkbases;
 
         /// <summary>
         /// A reference to the schema's presentation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public IEnumerable< PresentationLinkbaseDocument > PresentationLinkbase => thisLinkbaseDocuments.PresentationLinkbase;
+        public IEnumerable< PresentationLinkbaseDocument > PresentationLinkbases => thisLinkbaseDocuments.PresentationLinkbases;
 
         /// <summary>
         /// The namespace manager associated with the parsed schema document.
@@ -289,10 +289,10 @@ namespace JeffFerguson.Gepsio
         /// </returns>
         public CalculationLink GetCalculationLink(RoleType CalculationLinkRole)
         {
-            if (this.CalculationLinkbase == null)
+            if (this.CalculationLinkbases == null)
                 return null;
 
-			foreach( var linkbase in this.CalculationLinkbase ) 
+			foreach( var linkbase in this.CalculationLinkbases ) 
 			{
 				var calculationLinkCandidate = linkbase.GetCalculationLink( CalculationLinkRole );
 				if( calculationLinkCandidate != null )

--- a/JeffFerguson.Gepsio/XbrlSchema.cs
+++ b/JeffFerguson.Gepsio/XbrlSchema.cs
@@ -99,7 +99,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's label linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public LabelLinkbaseDocument LabelLinkbase => thisLinkbaseDocuments.LabelLinkbase;
+        public IEnumerable< LabelLinkbaseDocument > LabelLinkbase => thisLinkbaseDocuments.LabelLinkbase;
 
         /// <summary>
         /// A reference to the schema's presentation linkbase. Null is returned if no such linkbase is available.

--- a/JeffFerguson.Gepsio/XbrlSchema.cs
+++ b/JeffFerguson.Gepsio/XbrlSchema.cs
@@ -104,7 +104,7 @@ namespace JeffFerguson.Gepsio
         /// <summary>
         /// A reference to the schema's presentation linkbase. Null is returned if no such linkbase is available.
         /// </summary>
-        public PresentationLinkbaseDocument PresentationLinkbase => thisLinkbaseDocuments.PresentationLinkbase;
+        public IEnumerable< PresentationLinkbaseDocument > PresentationLinkbase => thisLinkbaseDocuments.PresentationLinkbase;
 
         /// <summary>
         /// The namespace manager associated with the parsed schema document.


### PR DESCRIPTION
Some taxonomies like ESRS (https://xbrl.efrag.org/taxonomy/draft-esrs/2023-07-31/esrs_all.xsd) has multiple linkbase documents for labels and presentation.